### PR TITLE
fix: Add phoneNumber check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -798,12 +798,20 @@ class PayfitContentScript extends ContentScript {
       },
       address: [],
       email: [],
-      phone: [
-        {
-          number: infos.phoneNumber,
-          type: this.determinePhoneType(infos.phoneNumber)
-        }
-      ]
+      phone: []
+    }
+    if (infos.phoneNumber) {
+      this.log('info', 'phoneNumber is defined, saving it')
+      userIdentity.phone.push({
+        number: infos.phoneNumber,
+        type: this.determinePhoneType(infos.phoneNumber)
+      })
+    } else {
+      this.log(
+        'info',
+        'phoneNumber is null, deleting phone entry from userIdentity'
+      )
+      delete userIdentity.phone
     }
     const foundAddress = this.getAddress(infos)
     for (const email of emails) {


### PR DESCRIPTION
This PR adds a phoneNumber check. Some user did not give a phone number for their account, leading the konnector to crash when trying to define if the number is a home phone or a mobile phone.

This fixes it by verifying if there's actually a number to save before treatment. If we cannot find one, we simply delete the key frome userIdentity object.