### PR TITLE
fix: Remove useless 'this' in autologin and display error from catch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,10 +171,10 @@ class PayfitContentScript extends ContentScript {
           try {
             await this.autoLogin(credentials)
             this.log('info', 'autoLogin succesful')
-          } catch {
+          } catch (err) {
             this.log(
               'info',
-              'Something went wrong with autoLogin, letting user log in'
+              'Something went wrong with autoLogin: ' + err.message
             )
             await this.showLoginFormAndWaitForAuthentication()
           }
@@ -288,7 +288,7 @@ class PayfitContentScript extends ContentScript {
       credentials.password
     )
     await this.runInWorker('click', passwordSubmitButtonSelector)
-    await this.Promise.race([
+    await Promise.race([
       this.waitForElementInWorker(burgerButtonSVGSelector),
       this.waitForElementInWorker('#code'),
       this.waitForElementInWorker('button[data-testid="accountButton"]')


### PR DESCRIPTION
This PR removes "this" from the autoLogin's Promise.race and add to the log the reason why the catch is taking over.

It was a little unseen mistake leading the autologin function to throw an error, interpreted by the try/catch statement as such and giving back to the user the visibility and control of the webview. This was intended in case of failed autologin, but not when working as expected. 
In this case, the webview would show herself for a split second, until the execution continues and the konnector notice we're already logged.