### PR TITLE
[SCR-57] fix : Reference mistake on account list sort

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -362,10 +362,10 @@ class PayfitContentScript extends ContentScript {
         .split('/')
         .reverse()
         .join('/')
-    this.store.accountList
+    this.store.accountList = this.store.accountList
       .filter(account => account?.account?.userRole !== 'admin') // ignore manager accounts (nothing to fetch)
-      .sort(
-        (a, b) => (getContractStart(a) < getContractStart(b) ? 1 : -1) // with fetch latest contract first
+    this.store.accountList.sort(
+        (a, b) => (getContractStart(a) < getContractStart(b) ? 1 : -1) // will fetch latest contract first
       )
 
     if (!FORCE_FETCH_ALL) {

--- a/src/index.js
+++ b/src/index.js
@@ -287,18 +287,15 @@ class PayfitContentScript extends ContentScript {
    * really cleared
    */
   async waitForClearedLocalStorage() {
-    await waitFor(
-      () => Object.keys(window.localStorage).length === 0,
-      {
-        interval: 1000,
-        timeout: {
-          milliseconds: 10 * 1000,
-          message: new TimeoutError(
-            `waitForClearedLocalStorage timed out after ${10 * 1000}ms`
-          )
-        }
+    await waitFor(() => Object.keys(window.localStorage).length === 0, {
+      interval: 1000,
+      timeout: {
+        milliseconds: 10 * 1000,
+        message: new TimeoutError(
+          `waitForClearedLocalStorage timed out after ${10 * 1000}ms`
+        )
       }
-    )
+    })
     return true
   }
 


### PR DESCRIPTION
This allows when optimizing the execution by context, to really download
the payslip on the last contract

- fix: lint
