### PR TITLE
[SCR-65] fix: showAccountList: reload the page only when needed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -321,14 +321,18 @@ class PayfitContentScript extends ContentScript {
   }
 
   async showAccountSwitchPage() {
-    // force the account choice page
+    // force the account choice page by clearing the localStorage when needed
+    const currentUrl = await this.evaluateInWorker(() => window.location.href)
     await this.evaluateInWorker(() => window.localStorage.clear())
     await this.runInWorkerUntilTrue({
       method: 'waitForClearedLocalStorage',
       timeout: 30 * 1000
     })
-    await this.goto(baseUrl)
-    await this.evaluateInWorker(() => window.location.reload()) // refresh the current page after localStorage update
+    if (currentUrl !== baseUrl) {
+      await this.goto(baseUrl)
+    } else {
+      await this.evaluateInWorker(() => window.location.reload()) // refresh the current page after localStorage update
+    }
     const accountList = await this.waitForInterception('accountList')
     this.store.accountList = accountList.response
   }

--- a/src/index.js
+++ b/src/index.js
@@ -330,14 +330,13 @@ class PayfitContentScript extends ContentScript {
     await this.goto(baseUrl)
     await this.evaluateInWorker(() => window.location.reload()) // refresh the current page after localStorage update
     const accountList = await this.waitForInterception('accountList')
-    return accountList
+    this.store.accountList = accountList.response
   }
 
   async getUserDataFromWebsite() {
     this.log('info', '🤖 getUserDataFromWebsite')
 
-    const accountList = await this.showAccountSwitchPage()
-    this.store.accountList = accountList.response
+    await this.showAccountSwitchPage()
 
     // find the user email in store or saved credentials
     const sourceAccountIdentifier =

--- a/src/index.js
+++ b/src/index.js
@@ -324,7 +324,8 @@ class PayfitContentScript extends ContentScript {
     // force the account choice page
     await this.evaluateInWorker(() => window.localStorage.clear())
     await this.runInWorkerUntilTrue({
-      method: 'waitForClearedLocalStorage'
+      method: 'waitForClearedLocalStorage',
+      timeout: 30 * 1000
     })
     await this.goto(baseUrl)
     await this.evaluateInWorker(() => window.location.reload()) // refresh the current page after localStorage update
@@ -402,7 +403,8 @@ class PayfitContentScript extends ContentScript {
       )
       await this.runInWorkerUntilTrue({
         method: 'waitForAccountInLocalStorage',
-        args: [account]
+        args: [account],
+        timeout: 30 * 1000
       })
       await this.goto(baseUrl)
       await this.evaluateInWorker(() => window.location.reload()) // refresh the current page after localStorage update


### PR DESCRIPTION
When we want to show the list of accounts, we don't need to force reload
the page page when the url is already different from the baseUrl. It
will save some time and the force reload may the cause of some freeze
errors for some users.


- feat: Add some time logs and other logs
- fix: Add timeouts on all runInWorkerUntilTrue
- refactor: Set the account list in the right place
