### PR TITLE
[SCR-980] fix: Modified url for accountList interception

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const requestInterceptor = new RequestInterceptor([
   {
     identifier: 'accountList',
     method: 'GET',
-    url: 'auth/auth0/accounts',
+    url: 'individuals-bff/auth0/accounts',
     serialization: 'json'
   },
   {


### PR DESCRIPTION
Changes on the website was causing the konnectors to end up in error. This fixes it